### PR TITLE
Clean up package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
-  "peerDependencies": {
-    "graphql": "0.12.x || 0.13.x || ^14.0.0"
-  },
   "scripts": {
     "build": "rimraf lib && tsc",
     "build:examples": "cd examples/basic && yarn build && cd ../basic2 && yarn build && cd ../features && yarn build && cd ../readme && yarn build",
@@ -36,6 +33,7 @@
     "prepublishOnly": "yarn build && yarn build:examples && yarn test"
   },
   "dependencies": {
+    "graphql": "^14.1.1",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
@@ -46,9 +44,7 @@
     "@types/rimraf": "^2.0.2",
     "@types/tape": "^4.2.33",
     "apollo-server-express": "^2.4.0",
-    "elm": "^0.19.0-bugfix6",
     "express": "^4.16.4",
-    "graphql": "^14.1.1",
     "phantom": "^6.0.3",
     "rimraf": "^2.6.2",
     "tap-diff": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "prepublishOnly": "yarn build && yarn build:examples && yarn test"
   },
   "dependencies": {
-    "graphql-to-elm-package": "^1.0.0",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {

--- a/src/graphqlToElm.ts
+++ b/src/graphqlToElm.ts
@@ -1,6 +1,5 @@
 import { resolve } from "path";
 import { GraphQLSchema, buildSchema } from "graphql";
-import { elmSrc, elmFiles } from "graphql-to-elm-package";
 import { Options, FinalOptions, finalizeOptions } from "./options";
 import { getSchemaString } from "./schema";
 import * as enums from "./enums";
@@ -82,17 +81,7 @@ export const writeResult = (result: Result): Promise<Result> => {
     })
   );
 
-  const writeLib = Promise.all(
-    elmFiles.map(file => {
-      const src = resolve(elmSrc, file);
-      const dest = resolve(result.options.dest, file);
-      return readFile(src)
-        .then(data => writeFileIfChanged(dest, data))
-        .then(logWrite(result.options, "lib", dest));
-    })
-  );
-
-  return Promise.all([writeEnums, writeQueries, writeLib])
+  return Promise.all([writeEnums, writeQueries])
     .then(() => result.options.log("done"))
     .then(() => result);
 };

--- a/src/queries/queryIntel.ts
+++ b/src/queries/queryIntel.ts
@@ -249,7 +249,8 @@ const nodeToInputField = (
   mapInputField(
     {
       name: node.variable.name.value,
-      type: getInputType(node, schema)
+      type: getInputType(node, schema),
+      extensions: null
     },
     schema
   );


### PR DESCRIPTION
This PR

- since our `prebuild.js` must `require("graphql-to-elm")` and that does a `require("graphql")`, it means "graphql" npm package is a direct dependency (as far as the cli is concern), not a devDependencies, nor peerDependencies
    - my project specifies `graphql-to-elm` as a `devDependencies`
- since elm actively suggest installing elm without using npm, we can simplify `package.json`
- minor fix on `src/queries/queryIntel.ts` missing property

The elm code generated from graphql files are wonderful, but the static library code that was written along with the process isn't so nice. Specifically, [`src/GraphQL/Http/Basic.elm`](https://github.com/harmboschloo/graphql-to-elm-package/blob/90c175ca0f47384ed4a69e646e2f0417d788654d/src/GraphQL/Http/Basic.elm) file is still using `elm/http v1.0.0`
- For elm 0.19 projects that are still somehow using `elm/http v1.0.0`, this probably work out of the box.
- But if an elm project has moved on to `v2.0.0`, then this otherwise awesome code generator appears broken!

If this codegen tool instead asked the developer to first 

```
elm install harmboschloo/graphql-to-elm-package
```

then at least elm package manager can kick in:

```
$ elm install harmboschloo/graphql-to-elm-package
Here is my plan:
  
  Add:
    harmboschloo/graphql-to-elm-package    1.0.0
  
  Change:
    elm/http                               2.0.0 => 1.0.0
  
  Remove:
    elm/bytes                              1.0.8
    elm/file                               1.0.5

Would you like me to update your elm.json accordingly? [Y/n]: 
```

### my usage

To ensure my app is always in sync with the `.graphql` files (which is shared and used by the server), I don't commit any `graphql-to-elm` generated code into my repo. During CI builds, we'll run our `prebuild.js` to generate the `.elm` code from the `.graphql` files, then perform `elm test` and `elm make`

But at the moment, there's an additional step to `rm -rf src/GraphQL/Http` after codegen.

### no http?

Or, since GraphQL is actually transport agnostic, might as well drop the `src/GraphQL/Http/Basic.elm` file and just provide example code that they can send their `Operation` like this

``` elm
post : String -> (Result Http.Error (Response e a) -> msg) -> Operation t e a -> Cmd msg
post url tagger operation =
    Http.post
        { url = url
        , body = Http.jsonBody (GraphQL.Operation.encode operation)
        , expect = Http.expectJson tagger (GraphQL.Response.decoder operation)
        }

-- send "/graphql" MessagesResponded Messages.query
```
