### PR TITLE
Export the encoder and decoder of `Variables`

### DIFF
--- a/src/gen/queries/elmIntel.ts
+++ b/src/gen/queries/elmIntel.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import { FinalOptions, TypeEncoder, TypeDecoder } from "../options";
 import { cachedValue, assertOk } from "../utils";
 import {
+  queryObjectInputAsOutput,
   QueryIntel,
   QueryOperation,
   QueryOperationType,
@@ -123,6 +124,7 @@ export interface ElmQueryOperation {
   query: string;
   fragments: string[];
   variables: ElmRecordEncoder | undefined;
+  variablesDecoder: ElmDecoder | undefined;
   data: ElmDecoder;
   errors: TypeDecoder;
   responseTypeName: string;
@@ -134,6 +136,7 @@ export interface ElmNamedOperation {
   name: string;
   gqlName: string;
   variables: ElmRecordEncoder | undefined;
+  variablesDecoder: ElmDecoder | undefined;
   data: ElmDecoder;
   errors: TypeDecoder;
   responseTypeName: string;
@@ -146,6 +149,7 @@ export interface ElmNamedPrefixedOperation {
   gqlName: string;
   gqlFilename: string;
   variables: ElmRecordEncoder | undefined;
+  variablesDecoder: ElmDecoder | undefined;
   data: ElmDecoder;
   errors: TypeDecoder;
   responseTypeName: string;
@@ -170,6 +174,10 @@ const getOperation = (
     ? getRecordEncoder(queryOperation.inputs, scope, options)
     : undefined;
 
+  const variablesDecoder: ElmDecoder | undefined = queryOperation.inputs
+    ? getCompositeDecoder(queryObjectInputAsOutput(queryOperation.inputs), scope, options)
+    : undefined;
+
   const data: ElmDecoder = getCompositeDecoder(
     queryOperation.outputs,
     scope,
@@ -192,6 +200,7 @@ const getOperation = (
         query: queryOperation.query,
         fragments: queryOperation.fragmentNames,
         variables,
+        variablesDecoder,
         data,
         errors,
         responseTypeName
@@ -203,6 +212,7 @@ const getOperation = (
         name,
         gqlName: assertOperationName(queryOperation),
         variables,
+        variablesDecoder,
         data,
         errors,
         responseTypeName
@@ -215,6 +225,7 @@ const getOperation = (
         gqlName: assertOperationName(queryOperation),
         gqlFilename: relativeSrc.replace(/\\/g, "/"),
         variables,
+        variablesDecoder,
         data,
         errors,
         responseTypeName

--- a/src/gen/queries/generateElm.ts
+++ b/src/gen/queries/generateElm.ts
@@ -67,6 +67,20 @@ const generateExports = (intel: ElmIntel): string => {
       });
     }
 
+    if (operation.variablesDecoder) {
+      visitDecoders(operation.variablesDecoder, {
+        value: (decoder: ElmValueDecoder) => {},
+        constantString: (decoder: ElmConstantStringDecoder) => {},
+        record: (decoder: ElmRecordDecoder) => {
+          addType(decoder.type);
+          addVariable(decoder.decoder);
+        },
+        union: (decoder: ElmUnionDecoder) => {},
+        unionOn: (decoder: ElmUnionOnDecoder) => {},
+        empty: (decoder: ElmEmptyDecoder) => {}
+      });
+    }
+
     visitDecoders(operation.data, {
       value: (decoder: ElmValueDecoder) => {},
       constantString: (decoder: ElmConstantStringDecoder) => {},
@@ -265,13 +279,16 @@ const generateEncodersAndDecoders = (intel: ElmIntel): string => {
   const newType = (type: string, createItems: () => string[]) => {
     if (!generatedTypes.includes(type)) {
       generatedTypes.push(type);
-      items.push(...createItems());
     }
+    items.push(...createItems());
   };
 
   intel.operations.map(operation => {
     if (operation.variables) {
       generateEncoders(operation.variables, newType, intel.scope);
+    }
+    if (operation.variablesDecoder) {
+      generateDecoders(operation.variablesDecoder, newType);
     }
     generateDecoders(operation.data, newType);
   });

--- a/src/gen/queries/generateElm.ts
+++ b/src/gen/queries/generateElm.ts
@@ -62,6 +62,7 @@ const generateExports = (intel: ElmIntel): string => {
       visitEncoders(operation.variables, {
         record: (encoder: ElmRecordEncoder) => {
           addType(encoder.type);
+          addVariable(encoder.encoder);
         },
         value: (encoder: ElmValueEncoder) => {}
       });

--- a/src/gen/queries/queryIntel.ts
+++ b/src/gen/queries/queryIntel.ts
@@ -825,3 +825,70 @@ const getAllIncludedTypes = (
 
   return types.reduce(helper, []);
 };
+
+
+// Convert Input types as compatible Output types
+
+const inputValueListItemWrapperAsOutput = (
+  inputWrapper: false | "non-null" | "optional"
+): false | "non-null" | "nullable" => {
+  switch (inputWrapper) {
+    case "optional":
+      return "nullable"
+    case "non-null":
+      return "non-null"
+    case false:
+      return false
+  }
+}
+
+
+const queryInputFieldAsOutput = (
+  inputField: QueryInputField
+): QueryOutputField => {
+  switch (inputField.value.kind) {
+    case "scalar":
+    case "enum":
+      return {
+        name: inputField.name,
+        value: queryInputAsOutput(inputField.value),
+        valueWrapper: inputField.valueWrapper,
+        valueListItemWrapper: inputValueListItemWrapperAsOutput(inputField.valueListItemWrapper),
+      }
+      break;
+
+    case "object":
+      return {
+        name: inputField.name,
+        value: queryInputAsOutput(inputField.value),
+        valueWrapper: inputField.valueWrapper,
+        valueListItemWrapper: inputValueListItemWrapperAsOutput(inputField.valueListItemWrapper),
+      }
+      break;
+  }
+}
+
+const queryInputAsOutput = (
+  input: QueryInput
+): QueryNonFragmentOutput => {
+  switch (input.kind) {
+    case "object":
+      return queryObjectInputAsOutput(input)
+
+    default:
+      return {
+        kind: input.kind,
+        typeName: input.typeName,
+      }
+  }
+}
+
+export const queryObjectInputAsOutput = (
+  input: QueryObjectInput
+): QueryCompositeNonFragmentOutput => {
+  return {
+    kind: "object",
+    typeName: input.typeName,
+    fields: input.fields.map(queryInputFieldAsOutput),
+  }
+}


### PR DESCRIPTION
Closes #12 

1. converts `queryOperation.inputs: QueryObjectInput` to `QueryCompositeNonFragmentOutput`
2. then we can `getCompositeDecoder` for our `queryOperation.inputs`
3. update `generateExports` and `generateEncodersAndDecoders` to include our new decoders

having a new decoder to work with `QueryCompositeNonFragmentOutput | QueryObjectInput` seem more correct but got hairy fast, so i went with the input conversion approach